### PR TITLE
Fix gh pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Build
         run: |
+          export IS_DEBUG=true
           make docs public
 
       - name: Upload artifact

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build:
     env:
-      TUGBOAT_PATH: '${{ github.workspace }}/tugboat'
+      TUGBOAT_PATH: '${{ github.workspace }}/repos/tugboat'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,8 +62,7 @@ jobs:
 
       - name: Build
         run: |
-          ./load-docs.sh --path ${{ env.TUGBOAT_PATH }}
-          make public
+          make docs public
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -60,10 +60,14 @@ jobs:
         with:
           go-version-file: '${{ env.TUGBOAT_PATH }}/go.mod'
 
+      - name: Download Go Dependencies
+        run: |
+          cd "${{ env.TUGBOAT_PATH }}"
+          go mod download
+
       - name: Build
         run: |
-          export IS_DEBUG=true
-          make docs public
+          IS_DEBUG=true make docs public
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
This PR fixes an issue where running the build picks up `go mod download` output when generating the cli documentation.